### PR TITLE
Remove geolocation check

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,20 +7,6 @@ app.config(function () {});//END config
 app.controller('AppCtrl', ['$scope', '$http',
  function ($scope, $http) {
 
-    //Geolocation
-    $scope.geolocationAllowed = true;
-    $scope.usersPosition = "";
-
-    var geolocationCallback = function(position){
-        $scope.usersPosition = position.coords.latitude + "," + position.coords.longitude;
-        $scope.$apply();
-    }
-    if (navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition(geolocationCallback);
-    } else {
-        $scope.geolocationAllowed = false;
-    }
-
     //Parking deck spaces data
     $scope.decks = [];
 

--- a/app/index.html
+++ b/app/index.html
@@ -38,7 +38,7 @@
                 <i class="fa fa-map-signs"></i>
             </h4>
             <div class="col-xs-12">
-                <a ng-href="http://maps.google.com/?saddr={{usersPosition}}&daddr={{deck.coords[0]}},{{deck.coords[1]}}" target = "_blank" class = "row list-group-item" ng-repeat = "deck in decks" style = "margin-top : 5px" >
+                <a ng-href="http://maps.google.com/?saddr=Current+Location&daddr={{deck.coords[0]}},{{deck.coords[1]}}" target = "_blank" class = "row list-group-item" ng-repeat = "deck in decks" style = "margin-top : 5px" >
                     <h3 class = text-info>{{deck.name}} 
                         <span class="pull-right"><strong>{{deck.available}}</strong> </span>
                     </h3>


### PR DESCRIPTION
Checking for geolocation triggers an [intrusive prompt on iOS](http://i.imgur.com/JJiWr0F.png). You have to interact with this dialog to even see the site — and the decision isn't remembered, so it's a continual annoyance.

Since geolocation is just used to format the Google Maps links, we can swap it with the [Current Location](https://gearside.com/easily-link-to-locations-and-directions-using-the-new-google-maps/) keyword to punt the geolocation check to when a user actual opens a map link.