### PR TITLE
Migrate deployment from GitHub pages to AWS Amplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ You can grab the feeds from these AWS S3 buckets:
 
 
 ## Deploying
-This is deployed on AWS Amplify on the main branch.  To deploy new changes, make commits to main branch and Amplify will automatically redeploy.
+This is deployed on AWS Amplify on the main branch.  To deploy new changes, make commits to main branch and Amplify will automatically redeploy.  The previous github pages deployment still exists at http://cityofasheville.github.io/wheres-parking/ , but is being redirected to the new site.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # wheres-parking
 
-Where’s Parking is a GitHub Pages hosted React app. The app makes a GET request to static JSON files in Amazon S3 buckets every 10 seconds to get fresh data. The JSON files for the Buncombe County garages are updated every minute by the County's parking vendor. The JSON files on S3 for the City of Asheville garages are loaded by the Lambda parking-data-parser (custom-asheville) from the Parking Logix API. https://github.com/cityofasheville/parking-data-parser
+Where’s Parking is a React app now hosted with AWS Amplify. The app makes a GET request to static JSON files in Amazon S3 buckets every 10 seconds to get fresh data. The JSON files for the Buncombe County garages are updated every minute by the County's parking vendor. The JSON files on S3 for the City of Asheville garages are loaded by the Lambda parking-data-parser (custom-asheville) from the Parking Logix API. https://github.com/cityofasheville/parking-data-parser
 
 Backend Code: https://github.com/cityofasheville/parking-data-parser 
 
-Where's Parking site: http://cityofasheville.github.io/wheres-parking/ (it's served from the gh-pages branch of this repo)
+Where's Parking site: https://wheresparking.ashevillenc.gov
 
 It is embedded in the City’s website here: https://www.ashevillenc.gov/service/find-real-time-parking-in-parking-garages/
 
@@ -18,8 +18,4 @@ You can grab the feeds from these AWS S3 buckets:
 
 
 ## Deploying
-This is deployed on Github Pages, from the main branch. The gh-pages script creates the gh-pages branch only on the Github server, you don't need a local copy. To deploy:
-```
-  npm run predeply (sic)
-  npm run deploy
-```
+This is deployed on AWS Amplify on the main branch.  To deploy new changes, make commits to main branch and Amplify will automatically redeploy.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wheres-parking",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://cityofasheville.github.io/wheres-parking",
+  "homepage": ".",
   "dependencies": {
     "gh-pages": "^2.0.1",
     "react": "^17.0.2",

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials">
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,700" rel="stylesheet">
     <!--

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,700" rel="stylesheet">
     <!--

--- a/src/GarageCard.js
+++ b/src/GarageCard.js
@@ -22,7 +22,7 @@ const GarageCard = props => (
           />
           <span className="GarageCard-name-text">
             { 
-              props.name.length > 3 && props.name.substring(props.name.length - 6) === 'Garage' ? props.name.substring(0, props.name.length - 7)
+              props.name.includes('Center') || props.name.includes('Garage') ? props.name.replace(/Center/, '').replace(/Garage$/, '').replace(/\./g, '').trim()
               :
               props.name
             }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-// import registerServiceWorker from './registerServiceWorker';
+import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render(<App />, document.getElementById('root'));
-// registerServiceWorker();
+registerServiceWorker();

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-import registerServiceWorker from './registerServiceWorker';
+// import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render(<App />, document.getElementById('root'));
-registerServiceWorker();
+// registerServiceWorker();


### PR DESCRIPTION
Migrate deployment from GitHub pages to AWS Amplify.  The old gh pages site is still available, but it is just redirecting to the new Amplify deployment.